### PR TITLE
Custom state components and channel enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ A component to define which parts of the tree should be rendered for a set of st
 <table>
 <thead><tr><th>Prop</th><th>Type</th><th>Default value</th><th>Description</th></tr></thead>
 <tbody>
-  <tr><td>is</td><td>arrayOf(string)</td><td>N/A (required)</td> <td>The states(s) for which the children should be shown. Available states: <code>'idle'</code>, <code>'loading'</code>, <code>'timeout'</code>, <code>'success'</code>, <code>'error'</code></td></tr>
+  <tr><td>is</td><td>oneOfType(arrayOf(string), string)</td><td>N/A (required)</td> <td>The states(s) for which the children should be shown. Available states: <code>'idle'</code>, <code>'loading'</code>, <code>'timeout'</code>, <code>'success'</code>, <code>'error'</code></td></tr>
   <tr><td>channel</td><td>string</td><td><code>null</code></td> <td>The key of the context from where to read the state.</td></tr>
   <tr><td>children</td><td>oneOfType(node, func)</td><td>N/A (required)</td> <td>The children to be rendered when the
   conditions match. Can also pass children as a function (render props).</td></tr>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-loads
+# React Loads
 
 > A simple, declarative and lightweight React component to handle loading state. Powered by [React Automata](https://github.com/MicheleBertoli/react-automata)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-loads
 
-> A simple, declarative and lightweight (1.11kB) React component to handle loading state.
+> A simple, declarative and lightweight React component to handle loading state. Powered by [React Automata](https://github.com/MicheleBertoli/react-automata)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -102,24 +102,12 @@ These components determine what node to render based on the loading/response sta
 <thead><tr><th>Prop</th><th>Type</th><th>Default value</th><th>Description</th></tr></thead>
 <tbody>
   <tr><td>channel</td><td>string</td><td><code>null</code></td> <td>The key of the context from where to read the state.</td></tr>
-  <tr><td>children</td><td>oneOfType(node, func)</td><td>N/A (required)</td> <td>The children to be rendered when the
-  conditions match. Can also pass children as a function (render props).</td></tr>
+  <tr><td>children</td><td>node</td><td>N/A (required)</td> <td>The children to be rendered when the
+  conditions match.</td></tr>
   <tr><td>onShow</td><td>func</td><td></td> <td>The function invoked when the component becomes visible.</td></tr>
   <tr><td>onHide</td><td>func</td><td></td> <td>The function invoked when the component becomes hidden.</td></tr>
 </tbody>
 </table>
-
-```jsx
-<IfSuccess>
-  Yaaassss!
-</IfSuccess>
-```
-
-```jsx
-<IfError>
-  {visible => visible && <div>An error occured.</div>}
-</IfError>
-```
 
 ### `<IfState>`
 
@@ -132,8 +120,8 @@ A component to define which parts of the tree should be rendered for a set of st
 <tbody>
   <tr><td>is</td><td>oneOfType(arrayOf(string), string)</td><td>N/A (required)</td> <td>The states(s) for which the children should be shown. Available states: <code>'idle'</code>, <code>'loading'</code>, <code>'timeout'</code>, <code>'success'</code>, <code>'error'</code></td></tr>
   <tr><td>channel</td><td>string</td><td><code>null</code></td> <td>The key of the context from where to read the state.</td></tr>
-  <tr><td>children</td><td>oneOfType(node, func)</td><td>N/A (required)</td> <td>The children to be rendered when the
-  conditions match. Can also pass children as a function (render props).</td></tr>
+  <tr><td>children</td><td>node</td><td>N/A (required)</td> <td>The children to be rendered when the
+  conditions match.</td></tr>
   <tr><td>onShow</td><td>func</td><td></td> <td>The function invoked when the component becomes visible.</td></tr>
   <tr><td>onHide</td><td>func</td><td></td> <td>The function invoked when the component becomes hidden.</td></tr>
 </tbody>
@@ -142,12 +130,6 @@ A component to define which parts of the tree should be rendered for a set of st
 ```jsx
 <IfState is={['idle', 'success']}>
   Hello world!
-</IfState>
-```
-
-```jsx
-<IfState is={['idle', 'success']}>
-  {visible => visible && <div>Hello world!</div>}
 </IfState>
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm install react-loads
 
 ```js
 import React from 'react';
-import Loads, { Action } from 'react-loads';
+import Loads, { IfIdle, IfLoading, IfTimeout, IfSuccess, IfError } from 'react-loads';
 
 const getRandomDog = () => axios.get('https://dog.ceo/api/breeds/image/random');
 
@@ -44,18 +44,18 @@ export default () => (
   <Loads fn={getRandomDog}>
     {({ load, response, error }) => (
       <div>
-        <Action show="idle">
+        <IfIdle>
           <button onClick={load}>Load random dog</button>
-        </Action>
-        <Action show="loading">loading...</Action>
-        <Action show="timeout">taking a while...</Action>
-        <Action show="success">
+        </IfIdle>
+        <IfLoading>loading...</IfLoading>
+        <IfTimeout>taking a while...</IfTimeout>
+        <IfSuccess>
           {response && <img src={response.data.message} alt="Dog" />}
           <div>
             <button onClick={load}>Load another dog</button>
           </div>
-        </Action>
-        <Action show="error">Error! {error}</Action>
+        </IfSuccess>
+        <IfError>Error! {error}</IfError>
       </div>
     )}
   </Loads>
@@ -84,20 +84,72 @@ export default () => (
 </tbody>
 </table>
 
-### `<Action>`
+### `<IfIdle>`, `<IfLoading>`, `<IfTimeout>`, `<IfSuccess>`, `<IfError>`
 
-A component to define which parts of the tree should be rendered for a given action (or set of actions).
+These components determine what node to render based on the loading/response state.
+
+#### Definitions
+
+- `IfIdle` - Will render when the state is 'idle' (the initial state).
+- `IfLoading` - Will render when the state is 'loading' (triggered when the promise (`fn`) is pending).
+- `IfTimeout` - Will render when the state is 'timeout' (triggered when the promise (`fn`) has not resolved/rejected after a period of time).
+- `IfSuccess` - Will render when the state is 'success' (triggered when the promise (`fn`) resolves).
+- `IfError` - Will render when the state is 'error' (triggered when the promise (`fn`) rejects).
 
 #### Props
-
-This component is just an export of `<Action>` from [React Automata](https://github.com/MicheleBertoli/react-automata#action-).
 
 <table>
 <thead><tr><th>Prop</th><th>Type</th><th>Default value</th><th>Description</th></tr></thead>
 <tbody>
-  <tr><td>show</td><td>oneOfType(string, arrayOf(string))</td><td>N/A (required)</td> <td>The action(s) for which the children should be shown. Available actions: <code>'idle'</code>, <code>'loading'</code>, <code>'timeout'</code>, <code>'success'</code>, <code>'error'</code></td></tr>
+  <tr><td>channel</td><td>string</td><td><code>null</code></td> <td>The key of the context from where to read the state.</td></tr>
+  <tr><td>children</td><td>oneOfType(node, func)</td><td>N/A (required)</td> <td>The children to be rendered when the
+  conditions match. Can also pass children as a function (render props).</td></tr>
+  <tr><td>onShow</td><td>func</td><td></td> <td>The function invoked when the component becomes visible.</td></tr>
+  <tr><td>onHide</td><td>func</td><td></td> <td>The function invoked when the component becomes hidden.</td></tr>
 </tbody>
 </table>
+
+```jsx
+<IfSuccess>
+  Yaaassss!
+</IfSuccess>
+```
+
+```jsx
+<IfError>
+  {visible => visible && <div>An error occured.</div>}
+</IfError>
+```
+
+### `<IfState>`
+
+A component to define which parts of the tree should be rendered for a set of states.
+
+#### Props
+
+<table>
+<thead><tr><th>Prop</th><th>Type</th><th>Default value</th><th>Description</th></tr></thead>
+<tbody>
+  <tr><td>is</td><td>arrayOf(string)</td><td>N/A (required)</td> <td>The states(s) for which the children should be shown. Available states: <code>'idle'</code>, <code>'loading'</code>, <code>'timeout'</code>, <code>'success'</code>, <code>'error'</code></td></tr>
+  <tr><td>channel</td><td>string</td><td><code>null</code></td> <td>The key of the context from where to read the state.</td></tr>
+  <tr><td>children</td><td>oneOfType(node, func)</td><td>N/A (required)</td> <td>The children to be rendered when the
+  conditions match. Can also pass children as a function (render props).</td></tr>
+  <tr><td>onShow</td><td>func</td><td></td> <td>The function invoked when the component becomes visible.</td></tr>
+  <tr><td>onHide</td><td>func</td><td></td> <td>The function invoked when the component becomes hidden.</td></tr>
+</tbody>
+</table>
+
+```jsx
+<IfState is={['idle', 'success']}>
+  Hello world!
+</IfState>
+```
+
+```jsx
+<IfState is={['idle', 'success']}>
+  {visible => visible && <div>Hello world!</div>}
+</IfState>
+```
 
 ## Special thanks
 

--- a/src/__stories__/index.stories.js
+++ b/src/__stories__/index.stories.js
@@ -3,7 +3,7 @@
 import React, { Fragment } from 'react';
 import { storiesOf } from '@storybook/react';
 import axios from 'axios';
-import Loads, { Action } from '../index';
+import Loads, { IfState, IfIdle, IfLoading, IfSuccess, IfTimeout, IfError } from '../index';
 
 storiesOf('Loads', module)
   .add('default usage', () => {
@@ -13,17 +13,17 @@ storiesOf('Loads', module)
         {({ load, response, state, error }) => (
           <div>
             <p>Current state: {state}</p>
-            <Action show="idle">
+            <IfIdle>
               <button onClick={load}>Load random dog</button>
-            </Action>
-            <Action show="loading">loading...</Action>
-            <Action show="success">
+            </IfIdle>
+            <IfLoading>loading...</IfLoading>
+            <IfSuccess>
               {response && <img src={response.data.message} alt="Dog" />}
               <div>
                 <button onClick={load}>Load another dog</button>
               </div>
-            </Action>
-            <Action show="error">Error! {error}</Action>
+            </IfSuccess>
+            <IfError>Error! {error}</IfError>
           </div>
         )}
       </Loads>
@@ -36,17 +36,17 @@ storiesOf('Loads', module)
         {({ load, response, state, error }) => (
           <div>
             <p>Current state: {state}</p>
-            <Action show="idle">
+            <IfIdle>
               <button onClick={load}>Load random dog</button>
-            </Action>
-            <Action show="loading">loading...</Action>
-            <Action show="success">
+            </IfIdle>
+            <IfLoading>loading...</IfLoading>
+            <IfSuccess>
               {response && <img src={response.data.message} alt="Dog" />}
               <div>
                 <button onClick={load}>Load another dog</button>
               </div>
-            </Action>
-            <Action show="error">Error! {error}</Action>
+            </IfSuccess>
+            <IfError>Error! {error}</IfError>
           </div>
         )}
       </Loads>
@@ -59,17 +59,17 @@ storiesOf('Loads', module)
         {({ load, response, state, error }) => (
           <Fragment>
             <p>Current state: {state}</p>
-            <Action show="idle">
+            <IfIdle>
               <button onClick={load}>Load random dog</button>
-            </Action>
-            <Action show="loading">loading...</Action>
-            <Action show="success">
+            </IfIdle>
+            <IfLoading>loading...</IfLoading>
+            <IfSuccess>
               {response && <img src={response.data.message} alt="Dog" />}
               <div>
                 <button onClick={load}>Load another dog</button>
               </div>
-            </Action>
-            <Action show="error">Error! {error}</Action>
+            </IfSuccess>
+            <IfError>Error! {error}</IfError>
           </Fragment>
         )}
       </Loads>
@@ -84,17 +84,17 @@ storiesOf('Loads', module)
         {({ load, response, state, error }) => (
           <Fragment>
             <p>Current state: {state}</p>
-            <Action show="idle">
+            <IfIdle>
               <button onClick={load}>Load random dog</button>
-            </Action>
-            <Action show="loading">loading...</Action>
-            <Action show="success">
+            </IfIdle>
+            <IfLoading>loading...</IfLoading>
+            <IfSuccess>
               {response && <img src={response.data.message} alt="Dog" />}
               <div>
                 <button onClick={load}>Load another dog</button>
               </div>
-            </Action>
-            <Action show="error">Error! {error && error.message}</Action>
+            </IfSuccess>
+            <IfError>Error! {error && error.message}</IfError>
           </Fragment>
         )}
       </Loads>
@@ -108,18 +108,18 @@ storiesOf('Loads', module)
         {({ load, response, state, error }) => (
           <Fragment>
             <p>Current state: {state}</p>
-            <Action show="idle">
+            <IfIdle>
               <button onClick={load}>Load random dog</button>
-            </Action>
-            <Action show="loading">loading...</Action>
-            <Action show="timeout">taking a while...</Action>
-            <Action show="success">
+            </IfIdle>
+            <IfLoading>loading...</IfLoading>
+            <IfTimeout>taking a while...</IfTimeout>
+            <IfSuccess>
               {response && <img src={response.data.message} alt="Dog" />}
               <div>
                 <button onClick={load}>Load another dog</button>
               </div>
-            </Action>
-            <Action show="error">Error! {error && error.message}</Action>
+            </IfSuccess>
+            <IfError>Error! {error && error.message}</IfError>
           </Fragment>
         )}
       </Loads>
@@ -132,17 +132,17 @@ storiesOf('Loads', module)
         {({ load, response, state, error }) => (
           <div>
             <p>Current state: {state}</p>
-            <Action show="idle">
+            <IfIdle>
               <button onClick={() => load('beagle')}>Load random beagle</button>
-            </Action>
-            <Action show="loading">loading...</Action>
-            <Action show="success">
+            </IfIdle>
+            <IfLoading>loading...</IfLoading>
+            <IfSuccess>
               {response && <img src={response.data.message} alt="Dog" />}
               <div>
                 <button onClick={() => load('beagle')}>Load another beagle</button>
               </div>
-            </Action>
-            <Action show="error">Error! {error}</Action>
+            </IfSuccess>
+            <IfError>Error! {error}</IfError>
           </div>
         )}
       </Loads>
@@ -152,26 +152,26 @@ storiesOf('Loads', module)
     const getRandomDog = () => axios.get(`https://dog.ceo/api/breeds/image/random`);
     const saveDog = randomDogResponse => new Promise(resolve => setTimeout(() => resolve(randomDogResponse), 1000));
     return (
-      <Loads name="randomDog" fn={getRandomDog}>
-        {({ Action: RandomDogAction, load: loadRandomDog, response: randomDogResponse, error: randomDogError }) => (
-          <Loads name="saveDog" fn={saveDog}>
-            {({ Action: SaveDogAction, load: saveDog }) => (
+      <Loads channel="randomDog" fn={getRandomDog}>
+        {({ load: loadRandomDog, response: randomDogResponse, error: randomDogError }) => (
+          <Loads channel="saveDog" fn={saveDog}>
+            {({ load: saveDog, state: saveDogState }) => (
               <div>
-                <RandomDogAction show="idle">
+                <IfIdle channel="randomDog">
                   <button onClick={loadRandomDog}>Load random dog</button>
-                </RandomDogAction>
-                <RandomDogAction show="loading">loading...</RandomDogAction>
-                <RandomDogAction show="success">
+                </IfIdle>
+                <IfLoading channel="randomDog">loading...</IfLoading>
+                <IfSuccess channel="randomDog">
                   {randomDogResponse && <img src={randomDogResponse.data.message} alt="Dog" />}
                   <div>
-                    <SaveDogAction show="idle">
+                    <IfLoading channel="saveDog">saving...</IfLoading>
+                    <IfSuccess channel="saveDog">saved dog!</IfSuccess>
+                    <IfState is={['idle', 'success']} channel="saveDog">
                       <button onClick={() => saveDog(randomDogResponse)}>Save dog</button>
-                    </SaveDogAction>
-                    <SaveDogAction show="loading">saving...</SaveDogAction>
-                    <SaveDogAction show="success">saved dog!</SaveDogAction>
+                    </IfState>
                   </div>
-                </RandomDogAction>
-                <RandomDogAction show="error">Error! {randomDogError}</RandomDogAction>
+                </IfSuccess>
+                <IfError channel="randomDog">Error! {randomDogError}</IfError>
               </div>
             )}
           </Loads>

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,13 +2,13 @@
 import React, { type Node } from 'react';
 import { Action } from 'react-automata';
 
-type States = 'success' | 'error' | 'timeout' | 'loading' | 'idle';
+type State = 'success' | 'error' | 'timeout' | 'loading' | 'idle';
 type ActionProps = {
   channel?: string,
   children: Function | Node
 };
 
-export const IfState = ({ channel, children, is, ...props }: { ...ActionProps, is: Array<States> }) =>
+export const IfState = ({ channel, children, is, ...props }: { ...ActionProps, is: Array<State> | State }) =>
   typeof children === 'function' ? (
     <Action channel={channel} show={is} {...props} render={children} />
   ) : (
@@ -16,8 +16,8 @@ export const IfState = ({ channel, children, is, ...props }: { ...ActionProps, i
       {children}
     </Action>
   );
-export const IfIdle = (props: ActionProps) => IfState({ is: ['idle'], ...props });
-export const IfLoading = (props: ActionProps) => IfState({ is: ['loading'], ...props });
-export const IfTimeout = (props: ActionProps) => IfState({ is: ['timeout'], ...props });
-export const IfSuccess = (props: ActionProps) => IfState({ is: ['success'], ...props });
-export const IfError = (props: ActionProps) => IfState({ is: ['error'], ...props });
+export const IfIdle = (props: ActionProps) => IfState({ is: 'idle', ...props });
+export const IfLoading = (props: ActionProps) => IfState({ is: 'loading', ...props });
+export const IfTimeout = (props: ActionProps) => IfState({ is: 'timeout', ...props });
+export const IfSuccess = (props: ActionProps) => IfState({ is: 'success', ...props });
+export const IfError = (props: ActionProps) => IfState({ is: 'error', ...props });

--- a/src/actions.js
+++ b/src/actions.js
@@ -5,17 +5,14 @@ import { Action } from 'react-automata';
 type State = 'success' | 'error' | 'timeout' | 'loading' | 'idle';
 type StateProps = {
   channel?: string,
-  children: Function | Node
+  children: Node
 };
 
-export const IfState = ({ channel, children, is, ...props }: { ...StateProps, is: Array<State> | State }) =>
-  typeof children === 'function' ? (
-    <Action channel={channel} show={is} {...props} render={children} />
-  ) : (
-    <Action channel={channel} show={is} {...props}>
-      {children}
-    </Action>
-  );
+export const IfState = ({ channel, children, is, ...props }: { ...StateProps, is: Array<State> | State }) => (
+  <Action channel={channel} show={is} {...props}>
+    {children}
+  </Action>
+);
 export const IfIdle = (props: StateProps) => IfState({ is: 'idle', ...props });
 export const IfLoading = (props: StateProps) => IfState({ is: 'loading', ...props });
 export const IfTimeout = (props: StateProps) => IfState({ is: 'timeout', ...props });

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,0 +1,23 @@
+// @flow
+import React, { type Node } from 'react';
+import { Action as AutomataAction } from 'react-automata';
+
+type States = 'success' | 'error' | 'timeout' | 'loading' | 'idle';
+type ActionProps = {
+  channel?: string,
+  children: Function | Node
+};
+
+export const IfState = ({ channel, children, is, ...props }: { ...ActionProps, is: Array<States> }) =>
+  typeof children === 'function' ? (
+    <AutomataAction channel={channel} show={is} {...props} render={children} />
+  ) : (
+    <AutomataAction channel={channel} show={is} {...props}>
+      {children}
+    </AutomataAction>
+  );
+export const IfIdle = (props: ActionProps) => IfState({ is: ['idle'], ...props });
+export const IfLoading = (props: ActionProps) => IfState({ is: ['loading'], ...props });
+export const IfTimeout = (props: ActionProps) => IfState({ is: ['timeout'], ...props });
+export const IfSuccess = (props: ActionProps) => IfState({ is: ['success'], ...props });
+export const IfError = (props: ActionProps) => IfState({ is: ['error'], ...props });

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { type Node } from 'react';
-import { Action as AutomataAction } from 'react-automata';
+import { Action } from 'react-automata';
 
 type States = 'success' | 'error' | 'timeout' | 'loading' | 'idle';
 type ActionProps = {
@@ -10,11 +10,11 @@ type ActionProps = {
 
 export const IfState = ({ channel, children, is, ...props }: { ...ActionProps, is: Array<States> }) =>
   typeof children === 'function' ? (
-    <AutomataAction channel={channel} show={is} {...props} render={children} />
+    <Action channel={channel} show={is} {...props} render={children} />
   ) : (
-    <AutomataAction channel={channel} show={is} {...props}>
+    <Action channel={channel} show={is} {...props}>
       {children}
-    </AutomataAction>
+    </Action>
   );
 export const IfIdle = (props: ActionProps) => IfState({ is: ['idle'], ...props });
 export const IfLoading = (props: ActionProps) => IfState({ is: ['loading'], ...props });

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,12 +3,12 @@ import React, { type Node } from 'react';
 import { Action } from 'react-automata';
 
 type State = 'success' | 'error' | 'timeout' | 'loading' | 'idle';
-type ActionProps = {
+type StateProps = {
   channel?: string,
   children: Function | Node
 };
 
-export const IfState = ({ channel, children, is, ...props }: { ...ActionProps, is: Array<State> | State }) =>
+export const IfState = ({ channel, children, is, ...props }: { ...StateProps, is: Array<State> | State }) =>
   typeof children === 'function' ? (
     <Action channel={channel} show={is} {...props} render={children} />
   ) : (
@@ -16,8 +16,8 @@ export const IfState = ({ channel, children, is, ...props }: { ...ActionProps, i
       {children}
     </Action>
   );
-export const IfIdle = (props: ActionProps) => IfState({ is: 'idle', ...props });
-export const IfLoading = (props: ActionProps) => IfState({ is: 'loading', ...props });
-export const IfTimeout = (props: ActionProps) => IfState({ is: 'timeout', ...props });
-export const IfSuccess = (props: ActionProps) => IfState({ is: 'success', ...props });
-export const IfError = (props: ActionProps) => IfState({ is: 'error', ...props });
+export const IfIdle = (props: StateProps) => IfState({ is: 'idle', ...props });
+export const IfLoading = (props: StateProps) => IfState({ is: 'loading', ...props });
+export const IfTimeout = (props: StateProps) => IfState({ is: 'timeout', ...props });
+export const IfSuccess = (props: StateProps) => IfState({ is: 'success', ...props });
+export const IfError = (props: StateProps) => IfState({ is: 'error', ...props });

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 // @flow
 
-import React, { Component, createElement } from 'react';
-import { Action as AutomataAction, withStatechart } from 'react-automata';
-export { Action } from 'react-automata';
+import { Component, createElement } from 'react';
+import { withStatechart } from 'react-automata';
+export * from './actions';
 
 const statechart = {
   initial: 'idle',
@@ -55,7 +55,6 @@ type Props = {
   delay?: number,
   isErrorSilent?: boolean,
   loadOnMount?: boolean,
-  name?: string,
   fn: (...args: any) => Promise<any>,
   machineState: { value: string },
   timeout?: number,
@@ -71,7 +70,6 @@ class Loads extends Component<Props, State> {
     delay: 300,
     isErrorSilent: true,
     loadOnMount: false,
-    name: null,
     timeout: 0
   };
   _delayTimeout: any;
@@ -127,11 +125,10 @@ class Loads extends Component<Props, State> {
   };
 
   render = () => {
-    const { children, name, machineState } = this.props;
+    const { children, machineState } = this.props;
     const { error, response } = this.state;
     const state = machineState.value;
     return children({
-      Action: props => <AutomataAction channel={name} {...props} />,
       error,
       response,
       state,
@@ -140,9 +137,9 @@ class Loads extends Component<Props, State> {
   };
 }
 
-const _default = ({ name, ...props }: { name?: ?string }) =>
-  createElement(withStatechart(statechart, { channel: name })(Loads), { name, ...props });
+const _default = ({ channel, ...props }: { channel?: ?string }) =>
+  createElement(withStatechart(statechart, { channel })(Loads), props);
 
-_default.defaultProps = { name: null };
+_default.defaultProps = { channel: null };
 
 export default _default;


### PR DESCRIPTION
This PR adds a few features and enhancements to React Loads. 

- Remove `<Action>` as an export of `react-automata`, and create custom components for the finite set of states in React Loads (`idle`, `loading`, `timeout`, `success` and `error`)
  - Added `<IfIdle>`
  - Added `<IfLoading>`
  - Added `<IfTimeout>`
  - Added `<IfSuccess>`
  - Added `<IfError>`
  - Added `<IfState is={[ ... ]}>`  to support multiple states
- Renamed `<Loads>` prop `name` to `channel` as the custom state components will also make use of a `channel` prop for nested `<Loads>`.

[View the storybook for this PR](https://docs-xpponqzcbq.now.sh)