### PR TITLE
Prop to toggle background states for cached responses

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,9 +1,14 @@
-import { configure } from '@storybook/react';
+import React from 'react';
+import { configure, addDecorator } from '@storybook/react';
+import { LoadsProvider } from '../src'
 
-// automatically import all files ending in *.stories.js
+
 const req = require.context('../src/__stories__', true, /.stories.js$/);
+// automatically import all files ending in *.stories.js
 function loadStories() {
+  addDecorator(story => <LoadsProvider>{story()}</LoadsProvider>)
   req.keys().forEach((filename) => req(filename));
 }
+
 
 configure(loadStories, module);

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ export default () => (
 <thead><tr><th>Prop</th><th>Type</th><th>Default value</th><th>Description</th></tr></thead>
 <tbody>
   <tr><td>  fn </td><td><code>function()</code></td><td></td> <td>The function to invoke - <strong>it must return a promise</strong>.</td></tr>
+  <tr><td colspan="100">OPTIONAL PROPS</td></tr>
   <tr><td>  cacheKey </td><td><code>string</code></td><td></td> <td>Unique identifier to store the response/error data. Your application must be wrapped in a <code>&lt;LoadsProvider&gt;</code> to enable caching (see 'Caching response/error data' below).</td></tr>
   <tr><td>  delay </td><td><code>number</code></td><td><code>300</code></td> <td>Number of milliseconds before component transitions to <code>loading</code> state upon invoking <code>fn</code>/<code>load</code>.</td></tr>
   <tr><td>  loadOnMount </td><td><code>boolean</code></td><td><code>false</code></td> <td>Whether or not to invoke the <code>fn</code> on mount.</td></tr>

--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ export default () => (
 <thead><tr><th>Prop</th><th>Type</th><th>Default value</th><th>Description</th></tr></thead>
 <tbody>
   <tr><td>  fn </td><td><code>function()</code></td><td></td> <td>The function to invoke - <strong>it must return a promise</strong>.</td></tr>
-  <tr><td colspan="100">OPTIONAL PROPS</td></tr>
-  <tr><td>  cacheKey </td><td><code>string</code></td><td></td> <td>Unique identifier to store the response/error data. Your application must be wrapped in a <code>&lt;LoadsProvider&gt;</code> to enable caching (see 'Caching response/error data' below).</td></tr>
+  <tr><td colspan="100" style="height: 10px"></td></tr>
   <tr><td>  delay </td><td><code>number</code></td><td><code>300</code></td> <td>Number of milliseconds before component transitions to <code>loading</code> state upon invoking <code>fn</code>/<code>load</code>.</td></tr>
   <tr><td>  loadOnMount </td><td><code>boolean</code></td><td><code>false</code></td> <td>Whether or not to invoke the <code>fn</code> on mount.</td></tr>
   <tr><td>  timeout </td><td><code>number</code></td><td><code>0</code></td> <td>Number of milliseconds before component transitions to <code>timeout</code> state. Set to <code>0</code> to disable.</td></tr>
+  <tr><td colspan="100" style="height: 10px"></tr>
+  <tr><td>  cacheKey </td><td><code>string</code></td><td></td> <td>Unique identifier to store the response/error data in cache. Your application must be wrapped in a <code>&lt;LoadsProvider&gt;</code> to enable caching (see 'Caching response/error data' below).</td></tr>
+  <tr><td>enableBackgroundStates</td><td><code>boolean</code></td><td><code>false</code></td><td>If true and the data is in cache, <code>isIdle</code>, <code>isLoading</code> and <code>isTimeout</code> will be evaluated on subsequent loads. When <code>false</code> (default), these states are only evaluated on initial load and are falsy on subsequent loads - this is helpful if you want to show the cached response and not have a idle/loading/timeout indicator when <code>fn</code> is invoked again. You must have a  <code>cacheKey</code> set to enable background states.</td></tr>
 </tbody>
 </table>
 
@@ -96,7 +98,7 @@ export default () => (
   <tr><td>  hasResponseInCache </td><td><code>boolean</code></td><td>Returns <code>true</code> if data already exists in the context cache.</td></tr>
   <tr><td>  isIdle </td><td><code>boolean</code></td><td>Returns <code>true</code> if the state is idle (<code>fn</code> has not been triggered).</td></tr>
   <tr><td>  isLoading </td><td><code>boolean</code></td><td>Returns <code>true</code> if the state is loading (<code>fn</code> is in a pending state).</td></tr>
-  <tr><td>  isTimeout </td><td><code>boolean</code></td><td>Returns <code>true</code> if the state is timeout (<code>fn</code> is in a pending state for longer than `delay` milliseconds).</td></tr>
+  <tr><td>  isTimeout </td><td><code>boolean</code></td><td>Returns <code>true</code> if the state is timeout (<code>fn</code> is in a pending state for longer than <code>delay</code> milliseconds).</td></tr>
   <tr><td>  isSuccess </td><td><code>boolean</code></td><td>Returns <code>true</code> if the state is success (<code>fn</code> has been resolved).</td></tr>
   <tr><td>  isError </td><td><code>boolean</code></td><td>Returns <code>true</code> if the state is error (<code>fn</code> has been rejected).</td></tr>
   <tr><td>  resetState </td><td><code>function()</code></td><td>Reset state back to <code>idle</code>.</td></tr>
@@ -115,10 +117,10 @@ const getRandomDog = () => axios.get('https://dog.ceo/api/breeds/image/random');
 
 const RandomDog = () => (
   <Loads cacheKey="randomDog" loadOnMount fn={getRandomDog}>
-    {({ hasResponseInCache, isLoading, isSuccess, load, response }) => (
+    {({ isLoading, isSuccess, load, response }) => (
       <div>
         {isLoading && <div>loading...</div>}
-        {(isSuccess || hasResponseInCache) && (
+        {isSuccess && (
           <div>
             {response && <img src={response.data.message} alt="Dog" />}
             <div>

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
   ],
   "peerDependencies": {
     "react": ">=16.3.0",
-    "react-dom": "^16.0.0"
+    "react-dom": ">=16.3.0"
   },
   "dependencies": {
-    "react-automata": "^2.0.0"
+    "idx": "2.4.0",
+    "react-automata": "3.0.0"
   },
   "devDependencies": {
     "@medipass/eslint-config-react-medipass": "8.3.0",

--- a/src/Loads.js
+++ b/src/Loads.js
@@ -3,9 +3,7 @@ import idx from 'idx';
 import { EVENTS, STATES } from './statechart';
 
 type Props = {
-  enableBackgroundIdleState?: boolean,
-  enableBackgroundLoadingState?: boolean,
-  enableBackgroundTimeoutState?: boolean,
+  enableBackgroundStates?: boolean,
   cache?: {
     error?: any,
     response?: any,
@@ -39,13 +37,12 @@ type State = {
 
 export default class Loads extends Component<Props, State> {
   static defaultProps = {
+    enableBackgroundStates: false,
     delay: 300,
     error: null,
     isErrorSilent: true,
     loadOnMount: false,
     response: null,
-    enableBackgroundIdleState: false,
-    enableBackgroundLoadingState: false,
     timeout: 0
   };
   _delayTimeout: any;
@@ -136,14 +133,7 @@ export default class Loads extends Component<Props, State> {
   };
 
   render = () => {
-    const {
-      enableBackgroundIdleState,
-      enableBackgroundLoadingState,
-      enableBackgroundTimeoutState,
-      cache,
-      children,
-      machineState
-    } = this.props;
+    const { enableBackgroundStates, cache, children, machineState } = this.props;
     const { error, response } = this.state;
     const cacheState = cache ? cache.state : null;
     const hasResponseInCache = typeof cache !== 'undefined';
@@ -151,9 +141,9 @@ export default class Loads extends Component<Props, State> {
     const props = {
       error,
       hasResponseInCache,
-      isIdle: state === STATES.IDLE && (hasResponseInCache && enableBackgroundIdleState),
-      isLoading: state === STATES.LOADING && (hasResponseInCache && enableBackgroundLoadingState),
-      isTimeout: state === STATES.TIMEOUT && (hasResponseInCache && enableBackgroundTimeoutState),
+      isIdle: state === STATES.IDLE && (hasResponseInCache && enableBackgroundStates),
+      isLoading: state === STATES.LOADING && (hasResponseInCache && enableBackgroundStates),
+      isTimeout: state === STATES.TIMEOUT && (hasResponseInCache && enableBackgroundStates),
       isSuccess: state === STATES.SUCCESS || (hasResponseInCache && cacheState === STATES.SUCCESS),
       isError: state === STATES.ERROR || (hasResponseInCache && cacheState === STATES.ERROR),
       load: this.handleLoad,

--- a/src/Loads.js
+++ b/src/Loads.js
@@ -5,6 +5,7 @@ import { EVENTS, STATES } from './statechart';
 type Props = {
   enableBackgroundIdleState?: boolean,
   enableBackgroundLoadingState?: boolean,
+  enableBackgroundTimeoutState?: boolean,
   cache?: {
     error?: any,
     response?: any,
@@ -135,7 +136,14 @@ export default class Loads extends Component<Props, State> {
   };
 
   render = () => {
-    const { enableBackgroundIdleState, enableBackgroundLoadingState, cache, children, machineState } = this.props;
+    const {
+      enableBackgroundIdleState,
+      enableBackgroundLoadingState,
+      enableBackgroundTimeoutState,
+      cache,
+      children,
+      machineState
+    } = this.props;
     const { error, response } = this.state;
     const cacheState = cache ? cache.state : null;
     const hasResponseInCache = typeof cache !== 'undefined';
@@ -145,7 +153,7 @@ export default class Loads extends Component<Props, State> {
       hasResponseInCache,
       isIdle: state === STATES.IDLE && (hasResponseInCache && enableBackgroundIdleState),
       isLoading: state === STATES.LOADING && (hasResponseInCache && enableBackgroundLoadingState),
-      isTimeout: state === STATES.TIMEOUT,
+      isTimeout: state === STATES.TIMEOUT && (hasResponseInCache && enableBackgroundTimeoutState),
       isSuccess: state === STATES.SUCCESS || (hasResponseInCache && cacheState === STATES.SUCCESS),
       isError: state === STATES.ERROR || (hasResponseInCache && cacheState === STATES.ERROR),
       load: this.handleLoad,

--- a/src/Loads.js
+++ b/src/Loads.js
@@ -135,17 +135,17 @@ export default class Loads extends Component<Props, State> {
   render = () => {
     const { enableBackgroundStates, cache, children, machineState } = this.props;
     const { error, response } = this.state;
-    const cacheState = cache ? cache.state : null;
+    const cachedState = cache ? cache.state : null;
     const hasResponseInCache = typeof cache !== 'undefined';
     const state = machineState.value;
     const props = {
       error,
       hasResponseInCache,
-      isIdle: state === STATES.IDLE && (hasResponseInCache && enableBackgroundStates),
-      isLoading: state === STATES.LOADING && (hasResponseInCache && enableBackgroundStates),
-      isTimeout: state === STATES.TIMEOUT && (hasResponseInCache && enableBackgroundStates),
-      isSuccess: state === STATES.SUCCESS || (hasResponseInCache && cacheState === STATES.SUCCESS),
-      isError: state === STATES.ERROR || (hasResponseInCache && cacheState === STATES.ERROR),
+      isIdle: state === STATES.IDLE && (!hasResponseInCache || enableBackgroundStates),
+      isLoading: state === STATES.LOADING && (!hasResponseInCache || enableBackgroundStates),
+      isTimeout: state === STATES.TIMEOUT && (!hasResponseInCache || enableBackgroundStates),
+      isSuccess: state === STATES.SUCCESS || (hasResponseInCache && cachedState === STATES.SUCCESS),
+      isError: state === STATES.ERROR || (hasResponseInCache && cachedState === STATES.ERROR),
       load: this.handleLoad,
       resetState: () => this.transition(EVENTS.RESET),
       response,

--- a/src/Loads.js
+++ b/src/Loads.js
@@ -7,7 +7,7 @@ type Props = {
   cache?: {
     error?: any,
     response?: any,
-    state?: ?string
+    state?: ?(STATES.SUCCESS | STATES.ERROR)
   },
   children: ({
     error: any,

--- a/src/__stories__/index.stories.js
+++ b/src/__stories__/index.stories.js
@@ -209,26 +209,4 @@ storiesOf('Loads', module)
         )}
       </Loads>
     );
-  })
-  .add('load on mount (context cache)', () => {
-    const getRandomDog = () => axios.get('https://dog.ceo/api/breeds/image/random');
-    return (
-      <Loads cacheKey="random-dog" fn={getRandomDog}>
-        {({ isIdle, isLoading, isSuccess, load, response, state, error }) => (
-          <div>
-            <p>Current state: {state}</p>
-            {isIdle && <button onClick={load}>Load random dog</button>}
-            {isLoading && <div>loading...</div>}
-            {isSuccess && (
-              <div>
-                {response && <img src={response.data.message} alt="Dog" />}
-                <div>
-                  <button onClick={load}>Load another dog</button>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </Loads>
-    );
   });

--- a/src/__stories__/index.stories.js
+++ b/src/__stories__/index.stories.js
@@ -113,7 +113,7 @@ storiesOf('Loads', module)
                 </div>
               </div>
             )}
-            {isError && <div>Error! {error}</div>}
+            {isError && <div>Error! {error.message}</div>}
           </Fragment>
         )}
       </Loads>
@@ -206,6 +206,28 @@ storiesOf('Loads', module)
               </div>
             )}
           </Loads>
+        )}
+      </Loads>
+    );
+  })
+  .add('load on mount (context cache)', () => {
+    const getRandomDog = () => axios.get('https://dog.ceo/api/breeds/image/random');
+    return (
+      <Loads cacheKey="random-dog" fn={getRandomDog}>
+        {({ isIdle, isLoading, isSuccess, load, response, state, error }) => (
+          <div>
+            <p>Current state: {state}</p>
+            {isIdle && <button onClick={load}>Load random dog</button>}
+            {isLoading && <div>loading...</div>}
+            {isSuccess && (
+              <div>
+                {response && <img src={response.data.message} alt="Dog" />}
+                <div>
+                  <button onClick={load}>Load another dog</button>
+                </div>
+              </div>
+            )}
+          </div>
         )}
       </Loads>
     );

--- a/src/context.js
+++ b/src/context.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { type Node } from 'react';
+import { STATES } from './statechart';
 
 // $FlowFixMe
 const { Provider, Consumer } = React.createContext({ data: {}, setResponse: () => {} });
@@ -14,8 +15,13 @@ type ProviderState = {
 class LoadsProvider extends React.Component<ProviderProps, ProviderState> {
   state = { data: {} };
 
-  setResponse = (key: string, { response = null, error = null }: { response?: any, error?: any }) => {
-    this.setState({ data: { ...this.state.data, [key]: { response, error } } });
+  setResponse = (key: string, { response, error, state }: { response?: any, error?: any, state: string }) => {
+    const value = {
+      ...(state === STATES.SUCCESS ? { response } : {}),
+      ...(state === STATES.ERROR ? { error } : {}),
+      state
+    };
+    this.setState({ data: { ...this.state.data, [key]: value } });
   };
 
   render = () => {
@@ -35,9 +41,9 @@ class LoadsConsumer extends React.Component<ConsumerProps> {
     return (
       <Consumer>
         {context => {
+          const cache = context.data[cacheKey];
           return children({
-            ...context.data[cacheKey],
-            hasResponseInCache: typeof context.data[cacheKey] !== 'undefined',
+            cache,
             setResponse: data => context.setResponse(cacheKey, data)
           });
         }}

--- a/src/context.js
+++ b/src/context.js
@@ -40,13 +40,12 @@ class LoadsConsumer extends React.Component<ConsumerProps> {
     const { cacheKey, children } = this.props;
     return (
       <Consumer>
-        {context => {
-          const cache = context.data[cacheKey];
-          return children({
-            cache,
+        {context =>
+          children({
+            cache: context.data[cacheKey],
             setResponse: data => context.setResponse(cacheKey, data)
-          });
-        }}
+          })
+        }
       </Consumer>
     );
   };

--- a/src/context.js
+++ b/src/context.js
@@ -15,7 +15,10 @@ type ProviderState = {
 class LoadsProvider extends React.Component<ProviderProps, ProviderState> {
   state = { data: {} };
 
-  setResponse = (key: string, { response, error, state }: { response?: any, error?: any, state: string }) => {
+  setResponse = (
+    key: string,
+    { response, error, state }: { response?: any, error?: any, state: STATES.SUCCESS | STATES.ERROR }
+  ) => {
     const value = {
       ...(state === STATES.SUCCESS ? { response } : {}),
       ...(state === STATES.ERROR ? { error } : {}),

--- a/src/index.js
+++ b/src/index.js
@@ -3,63 +3,13 @@ import React from 'react';
 import { withStatechart } from 'react-automata';
 import Loads from './Loads';
 import LoadsContext from './context';
-
-const statechart = {
-  initial: 'idle',
-  states: {
-    idle: {
-      on: {
-        FETCH: 'loading',
-        SUCCESS: 'success',
-        ERROR: 'error'
-      }
-    },
-    loading: {
-      on: {
-        TIMEOUT: 'timeout',
-        SUCCESS: 'success',
-        ERROR: 'error'
-      }
-    },
-    timeout: {
-      on: {
-        FETCH: 'loading',
-        SUCCESS: 'success',
-        ERROR: 'error'
-      }
-    },
-    success: {
-      on: {
-        RESET: 'idle',
-        FETCH: 'loading',
-        SUCCESS: 'success',
-        ERROR: 'error'
-      }
-    },
-    error: {
-      on: {
-        RESET: 'idle',
-        FETCH: 'loading',
-        SUCCESS: 'success',
-        ERROR: 'error'
-      }
-    }
-  }
-};
+import statechart from './statechart';
 
 const LoadsContainer = (props: { cacheKey?: ?string }) => {
   if (props.cacheKey) {
     return (
       <LoadsContext.Consumer cacheKey={props.cacheKey}>
-        {({ error, hasResponseInCache, response, setResponse }) => (
-          <Loads
-            {...props}
-            error={error}
-            hasResponseInCache={hasResponseInCache}
-            response={response}
-            setResponse={setResponse}
-          />
-        )}
+        {({ cache, setResponse }) => <Loads {...props} cache={cache} setResponse={setResponse} />}
       </LoadsContext.Consumer>
     );
   }

--- a/src/statechart.js
+++ b/src/statechart.js
@@ -1,0 +1,58 @@
+export const EVENTS = {
+  ERROR: 'ERROR',
+  FETCH: 'FETCH',
+  RESET: 'RESET',
+  SUCCESS: 'SUCCESS',
+  TIMEOUT: 'TIMEOUT'
+};
+
+export const STATES = {
+  ERROR: 'error',
+  IDLE: 'idle',
+  LOADING: 'loading',
+  SUCCESS: 'success',
+  TIMEOUT: 'timeout'
+};
+
+export default {
+  initial: STATES.IDLE,
+  states: {
+    [STATES.IDLE]: {
+      on: {
+        [EVENTS.FETCH]: STATES.LOADING,
+        [EVENTS.SUCCESS]: STATES.SUCCESS,
+        [EVENTS.ERROR]: STATES.ERROR
+      }
+    },
+    [STATES.LOADING]: {
+      on: {
+        [EVENTS.TIMEOUT]: STATES.TIMEOUT,
+        [EVENTS.SUCCESS]: STATES.SUCCESS,
+        [EVENTS.ERROR]: STATES.ERROR
+      }
+    },
+    [STATES.TIMEOUT]: {
+      on: {
+        [EVENTS.FETCH]: STATES.LOADING,
+        [EVENTS.SUCCESS]: STATES.SUCCESS,
+        [EVENTS.ERROR]: STATES.ERROR
+      }
+    },
+    [STATES.SUCCESS]: {
+      on: {
+        [EVENTS.RESET]: STATES.IDLE,
+        [EVENTS.FETCH]: STATES.LOADING,
+        [EVENTS.SUCCESS]: STATES.SUCCESS,
+        [EVENTS.ERROR]: STATES.ERROR
+      }
+    },
+    [STATES.ERROR]: {
+      on: {
+        [EVENTS.RESET]: STATES.IDLE,
+        [EVENTS.FETCH]: STATES.LOADING,
+        [EVENTS.SUCCESS]: STATES.SUCCESS,
+        [EVENTS.ERROR]: STATES.ERROR
+      }
+    }
+  }
+};


### PR DESCRIPTION
This PR adds a prop `enableBackgroundStates` (boolean) to provide a simpler way to deal with cached responses and it's states.

Will amend the readme tomorrow.