### PR TITLE
Allow async storage for cache provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": ">=16.3.0"
   },
   "dependencies": {
+    "@reactions/component": "2.0.2",
     "idx": "2.4.0",
     "react-automata": "3.0.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,10 +12,11 @@ export default {
       react: 'React',
       'react-dom': 'ReactDOM',
       'react-automata': 'ReactAutomata',
-      idx: 'idx'
+      idx: 'idx',
+      '@reactions/component': 'Component'
     }
   },
-  external: ['react', 'react-dom', 'react-automata', 'idx'],
+  external: ['react', 'react-dom', 'react-automata', 'idx', '@reactions/component'],
   plugins: [
     babel({
       presets: [['env', { modules: false }], 'react'],

--- a/src/context.js
+++ b/src/context.js
@@ -18,7 +18,7 @@ type ProviderState = {
 class LoadsProvider extends React.Component<ProviderProps, ProviderState> {
   state = { data: {} };
 
-  setResponse = async (params: SetResponseParams) => {
+  setResponse = (params: SetResponseParams) => {
     const { cacheProvider: globalCacheProvider } = this.props;
     const {
       cacheKey,

--- a/src/context.js
+++ b/src/context.js
@@ -79,7 +79,7 @@ class LoadsConsumer extends React.Component<ConsumerProps> {
             didMount={({ state: { cacheProvider }, setState }) => {
               if (cacheProvider && cacheProvider.get) {
                 const cacheResponse = cacheProvider.get(cacheKey);
-                if (cacheResponse instanceof Promise) {
+                if (cacheResponse.then && typeof cacheResponse.then === 'function') {
                   return cacheResponse.then(cachedData => setState({ cachedData, hasLoaded: true })).catch(err => {
                     console.error(`Error loading data from cacheProvider (cacheKey: ${cacheKey}). Error: ${err}`);
                     setState({ hasLoaded: true });

--- a/src/context.js
+++ b/src/context.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { type Node } from 'react';
+import Component from '@reactions/component';
 import { type SetResponseParams, type CacheProvider } from './_types';
 import { STATES } from './statechart';
 
@@ -17,7 +18,7 @@ type ProviderState = {
 class LoadsProvider extends React.Component<ProviderProps, ProviderState> {
   state = { data: {} };
 
-  setResponse = (params: SetResponseParams) => {
+  setResponse = async (params: SetResponseParams) => {
     const { cacheProvider: globalCacheProvider } = this.props;
     const {
       cacheKey,
@@ -63,20 +64,36 @@ type ConsumerProps = {
 class LoadsConsumer extends React.Component<ConsumerProps> {
   render = () => {
     const { cacheKey, cacheProvider: localCacheProvider, children } = this.props;
-
     return (
       <Consumer>
-        {context => {
-          const cacheProvider = localCacheProvider || context.globalCacheProvider;
-          let cachedData = context.data[cacheKey];
-          if (cacheProvider && cacheProvider.get) {
-            cachedData = cacheProvider.get(cacheKey);
-          }
-          return children({
-            cache: cachedData,
-            setResponse: data => context.setResponse({ cacheKey, cacheProvider, data })
-          });
-        }}
+        {context => (
+          <Component
+            initialState={{
+              cachedData: context.data[cacheKey],
+              cacheProvider: localCacheProvider || context.globalCacheProvider,
+              hasLoaded: false
+            }}
+            didMount={({ state: { cacheProvider }, setState }) => {
+              if (cacheProvider && cacheProvider.get) {
+                const cacheResponse = cacheProvider.get(cacheKey);
+                if (cacheResponse instanceof Promise) {
+                  return cacheResponse.then(cachedData => setState({ cachedData, hasLoaded: true }));
+                }
+                setState({ cachedData: cacheResponse });
+              }
+              setState({ hasLoaded: true });
+            }}
+          >
+            {({ state: { cachedData, cacheProvider, hasLoaded } }) => {
+              return hasLoaded
+                ? children({
+                    cache: cachedData,
+                    setResponse: data => context.setResponse({ cacheKey, cacheProvider, data })
+                  })
+                : null;
+            }}
+          </Component>
+        )}
       </Consumer>
     );
   };

--- a/src/context.js
+++ b/src/context.js
@@ -5,7 +5,10 @@ import { type SetResponseParams, type CacheProvider } from './_types';
 import { STATES } from './statechart';
 
 // $FlowFixMe
-const { Provider, Consumer } = React.createContext({ data: {}, setResponse: () => {} });
+const { Provider, Consumer } = React.createContext({
+  data: {},
+  setResponse: () => {}
+});
 
 type ProviderProps = {
   children: Node,
@@ -77,7 +80,10 @@ class LoadsConsumer extends React.Component<ConsumerProps> {
               if (cacheProvider && cacheProvider.get) {
                 const cacheResponse = cacheProvider.get(cacheKey);
                 if (cacheResponse instanceof Promise) {
-                  return cacheResponse.then(cachedData => setState({ cachedData, hasLoaded: true }));
+                  return cacheResponse.then(cachedData => setState({ cachedData, hasLoaded: true })).catch(err => {
+                    console.error(`Error loading data from cacheProvider (cacheKey: ${cacheKey}). Error: ${err}`);
+                    setState({ hasLoaded: true });
+                  });
                 }
                 setState({ cachedData: cacheResponse });
               }


### PR DESCRIPTION
This allows `get` and `set` functions in the `cacheProvider` to be async (return a promise).