### PR TITLE
enhancement: spread options in LoadFunction type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export type LoadsConfig<Response, Err> = {
   update?: LoadFunction<Response>;
   variables?: Array<unknown> | (() => Array<unknown>);
 };
-export type LoadFunction<Response> = (opts?: any) => Promise<Response>;
+export type LoadFunction<Response> = (...opts: any) => Promise<Response>;
 export type LoadPolicy = 'cache-first' | 'cache-and-load' | 'load-only' | 'cache-only';
 export type LoadingState =
   | 'idle'


### PR DESCRIPTION
when using this function in deferredLoads, I'm getting `Type '(strategyId: string, body: Record<string, any>) => any' is not assignable to type 'LoadFunction<any>'.`. 

Not sure if this is a valid issue, maybe my code just sucks... :P

export const backtestStrategy = (
  strategyId: string,
  body: Record<string, any>,
) =>
  request({
    url: `/v1/backtest/strategies/${strategyId}`,
    method: 'POST',
    data: body,
  })