### PR TITLE
bug: reloadingSlow is not triggering

### DIFF
--- a/src/useLoads.ts
+++ b/src/useLoads.ts
@@ -119,7 +119,7 @@ export function useLoads<Response, Err>(
         case STATES.RELOADING:
           return { ...state, state: STATES.RELOADING };
         case STATES.RELOADING_SLOW:
-          return { ...state, state: STATES.RELOADING };
+          return { ...state, state: STATES.RELOADING_SLOW };
         default:
           return state;
       }


### PR DESCRIPTION
I've found a little bug. When reloading some data, it won't trigger the isReloadingSlow state.